### PR TITLE
Show message if Leap node is not available

### DIFF
--- a/src/components/appLayout.js
+++ b/src/components/appLayout.js
@@ -6,6 +6,7 @@
  */
 
 import React, { Fragment } from 'react';
+import { reaction } from 'mobx';
 import { observer, inject } from 'mobx-react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
@@ -39,6 +40,13 @@ class AppLayout extends React.Component {
   constructor(props) {
     super(props);
     props.bridge.address = props.bridgeAddr || props.bridge.defaultAddress;
+
+    reaction(
+      () => props.bridge.defaultAddress,
+      () => {
+        props.bridge.address = props.bridgeAddr || props.bridge.defaultAddress;
+      }
+    );
   }
 
   componentDidUpdate(prevProps) {
@@ -51,7 +59,11 @@ class AppLayout extends React.Component {
   render() {
     const { psc, account, web3, section, bridge, bridgeAddr } = this.props;
 
-    if (!account.ready) {
+    if (web3.plasmaReady === false) {
+      return <Message>No connection to Leap node</Message>;
+    }
+
+    if (!account.ready || web3.plasmaReady === undefined) {
       return (
         <Message hideBg>
           <Spin size="large" />
@@ -103,34 +115,30 @@ class AppLayout extends React.Component {
           <MediaQuery minWidth={1049}>{menu(true)}</MediaQuery>
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <span className="balance">
-              {psc &&
-                psc.balance &&
-                psc.ready && (
-                  <Fragment>
-                    Balance:{' '}
-                    <strong>
-                      <TokenValue value={psc.balance} color={psc.color} />
-                    </strong>
-                  </Fragment>
-                )}
-              {web3 &&
-                web3.injectedAvailable &&
-                !web3.injected && (
-                  <Button
-                    onClick={() => {
-                      web3.enable();
-                    }}
+              {psc && psc.balance && psc.ready && (
+                <Fragment>
+                  Balance:{' '}
+                  <strong>
+                    <TokenValue value={psc.balance} color={psc.color} />
+                  </strong>
+                </Fragment>
+              )}
+              {web3 && web3.injectedAvailable && !web3.injected && (
+                <Button
+                  onClick={() => {
+                    web3.enable();
+                  }}
+                >
+                  <span
+                    role="img"
+                    aria-label="fox"
+                    style={{ bottom: -1, position: 'relative' }}
                   >
-                    <span
-                      role="img"
-                      aria-label="fox"
-                      style={{ bottom: -1, position: 'relative' }}
-                    >
-                      🦊
-                    </span>{' '}
-                    Connect MetaMask
-                  </Button>
-                )}
+                    🦊
+                  </span>{' '}
+                  Connect MetaMask
+                </Button>
+              )}
             </span>
             <MediaQuery maxWidth={1048}>
               <Dropdown

--- a/src/index.js
+++ b/src/index.js
@@ -46,44 +46,37 @@ const network = new Network(
 );
 const unspents = new Unspents(bridge, account, node, web3);
 
-web3.plasma.getConfig().then(({ bridgeAddr }) => {
-  bridge.defaultAddress = bridgeAddr;
-  ReactDOM.render(
-    <BrowserRouter>
-      <Provider
-        {...{
-          account,
-          tokens,
-          bridge,
-          network,
-          transactions,
-          explorer,
-          unspents,
-          node,
-          web3,
-        }}
-      >
-        <Fragment>
-          <TxNotification />
-          <Route path="/" exact component={Slots} />
-          <Route
-            path="/:bridgeAddr(0x[0-9a-fA-f]{40})"
-            exact
-            component={Slots}
-          />
-          <Route path="/registerToken" exact component={RegisterToken} />
-          <Route
-            path="/registerToken/:bridgeAddr(0x[0-9a-fA-f]{40})"
-            exact
-            component={RegisterToken}
-          />
-          <Route path="/wallet" component={Wallet} />
-          <Route path="/explorer" component={Explorer} />
-          <Route path="/faucet" component={Faucet} />
-          <Route path="/status" component={Status} />
-        </Fragment>
-      </Provider>
-    </BrowserRouter>,
-    document.getElementById('app')
-  );
-});
+ReactDOM.render(
+  <BrowserRouter>
+    <Provider
+      {...{
+        account,
+        tokens,
+        bridge,
+        network,
+        transactions,
+        explorer,
+        unspents,
+        node,
+        web3,
+      }}
+    >
+      <Fragment>
+        <TxNotification />
+        <Route path="/" exact component={Slots} />
+        <Route path="/:bridgeAddr(0x[0-9a-fA-f]{40})" exact component={Slots} />
+        <Route path="/registerToken" exact component={RegisterToken} />
+        <Route
+          path="/registerToken/:bridgeAddr(0x[0-9a-fA-f]{40})"
+          exact
+          component={RegisterToken}
+        />
+        <Route path="/wallet" component={Wallet} />
+        <Route path="/explorer" component={Explorer} />
+        <Route path="/faucet" component={Faucet} />
+        <Route path="/status" component={Status} />
+      </Fragment>
+    </Provider>
+  </BrowserRouter>,
+  document.getElementById('app')
+);

--- a/src/routes/explorer.js
+++ b/src/routes/explorer.js
@@ -29,11 +29,6 @@ import Address from './address';
 }))
 @observer
 export default class Explorer extends React.Component {
-  constructor(props) {
-    super(props);
-    props.bridge.address = props.bridge.defaultAddress;
-  }
-
   @observable
   value = '';
 

--- a/src/routes/wallet/index.js
+++ b/src/routes/wallet/index.js
@@ -20,11 +20,6 @@ import AppLayout from '../../components/appLayout';
 @inject('tokens', 'bridge')
 @observer
 export default class Wallet extends React.Component {
-  constructor(props) {
-    super(props);
-    props.bridge.address = props.bridge.defaultAddress;
-  }
-
   @computed
   get selectedToken() {
     const { tokens } = this.props;
@@ -74,5 +69,4 @@ export default class Wallet extends React.Component {
 
 Wallet.propTypes = {
   tokens: PropTypes.object,
-  bridge: PropTypes.object,
 };

--- a/src/stores/bridge.ts
+++ b/src/stores/bridge.ts
@@ -64,9 +64,11 @@ const readSlots = (bridge: Contract) => {
 export default class Bridge extends ContractStore {
   @observable
   public slots: IObservableArray<Slot> = observable.array([]);
+
   @observable
   public lastCompleteEpoch: number;
 
+  @observable
   public defaultAddress: string;
 
   constructor(
@@ -76,6 +78,10 @@ export default class Bridge extends ContractStore {
     address?: string
   ) {
     super(bridgeAbi, address, transactions, web3);
+
+    web3.plasma.getConfig().then(({ bridgeAddr }) => {
+      this.defaultAddress = bridgeAddr;
+    });  
 
     reaction(() => {
       return this.contract;

--- a/src/stores/web3.ts
+++ b/src/stores/web3.ts
@@ -16,6 +16,9 @@ export default class Web3Store {
   @observable.ref
   public plasma: ExtendedWeb3;
 
+  @observable
+  public plasmaReady;
+
   @observable.ref
   public local: Web3Type;
 
@@ -34,6 +37,14 @@ export default class Web3Store {
     this.plasma = helpers.extendWeb3(
       new Web3(new Web3.providers.HttpProvider(plasmaProvider))
     );
+    this.plasma.eth.net.getId()
+      .then(_ => {
+        this.plasmaReady = true;
+      })
+      .catch(e => {
+        console.error('Leap node error', e);
+        this.plasmaReady = false;
+      });
 
     const localNetwork = NETWORKS[process.env.NETWORK_ID || DEFAULT_NETWORK];
     this.local = new Web3(


### PR DESCRIPTION
Changes overview:
- render the app before reading bridge config. There is no `bridge.defaultAccount` at this step.
- on render, check `plasmaReady` on web3 store which may be `undefined`(loading), `true` (connected) or `false` (no connection). If `undefined` show loading indicator, if `false` render `Node N/A` message instead of the app.
- in web3 store try reading `net_version` from Leap node. Set `plasmaReady` accordingly on result.
- make `bridge.defaultAccount` observable.

Requires https://github.com/leapdao/leap-node/pull/98 to work