### PR TITLE
fix ABI typedef on linux

### DIFF
--- a/src/stores/governanceContract.ts
+++ b/src/stores/governanceContract.ts
@@ -7,7 +7,7 @@
 import { reaction, observable, IObservableArray } from 'mobx';
 
 import Web3Store from './web3/';
-import { ABIDefinition, EthAbiDecodeParametersResultObject } from 'web3/Eth/ABI';
+import { ABIDefinition, EthAbiDecodeParametersResultObject } from 'web3/eth/abi';
 
 import { range, toArray } from '../utils';
 import { 

--- a/src/utils/abis/bridge.ts
+++ b/src/utils/abis/bridge.ts
@@ -1,4 +1,4 @@
-import { ABIDefinition } from 'web3/Eth/ABI';
+import { ABIDefinition } from 'web3/eth/abi';
 
 export default [
   {

--- a/src/utils/abis/exitHandler.ts
+++ b/src/utils/abis/exitHandler.ts
@@ -1,4 +1,4 @@
-import { ABIDefinition } from 'web3/Eth/ABI';
+import { ABIDefinition } from 'web3/eth/abi';
 
 export default [
   {

--- a/src/utils/abis/poaOperator.ts
+++ b/src/utils/abis/poaOperator.ts
@@ -1,4 +1,4 @@
-import { ABIDefinition } from 'web3/Eth/ABI';
+import { ABIDefinition } from 'web3/eth/abi';
 
 export default [
   {

--- a/src/utils/abis/posOperator.ts
+++ b/src/utils/abis/posOperator.ts
@@ -1,4 +1,4 @@
-import { ABIDefinition } from 'web3/Eth/ABI';
+import { ABIDefinition } from 'web3/eth/abi';
 
 export default [
   {

--- a/src/utils/abis/proxy.ts
+++ b/src/utils/abis/proxy.ts
@@ -1,4 +1,4 @@
-import { ABIDefinition } from 'web3/Eth/ABI';
+import { ABIDefinition } from 'web3/eth/abi';
 
 export default ([
   {


### PR DESCRIPTION
Resolves #109 

Superior to #110 because we continue using `@types/web3`, while #110 is mixing `@types/web3` with types from `web3-eth-abi`