### PR TITLE
replace https with wss

### DIFF
--- a/src/components/monitor.tsx
+++ b/src/components/monitor.tsx
@@ -3,6 +3,12 @@ import { List } from 'antd';
 import { NamedNodeEntry } from '../utils/types.d';
 
 function callMethod(node, method, params = []) {
+  // poorman's wss -> https fallback
+  // TODO: fix this, ideally don't use fetch, but web3
+  if (node.indexOf('wss') > -1) {
+    node = node.replace('wss', 'https');
+    node = node.replace(':1443', '');
+  }
   return fetch(node, {
     method: 'post',
     body: JSON.stringify({

--- a/src/config/mainnet/config.json
+++ b/src/config/mainnet/config.json
@@ -4,7 +4,7 @@
   "description": "Plasma network running transfer-only MoreVP governed by LeapDAO",
   "consensus": "poa",
   "nodes": [
-    "http://node1.mainnet.leapdao.org:8645"
+    "wss://mainnet-node1.leapdao.org:1443"
   ],
   "tokenFormUrl": "https://docs.google.com/forms/d/e/1FAIpQLSedGkkbHD6sdvdnnhJOg5bgLj0XsjU2caIsqyHQyzwmMjyZ9A/viewform?embedded=true",
   "exitMarketMaker": "",

--- a/src/config/testnet/config.json
+++ b/src/config/testnet/config.json
@@ -4,7 +4,7 @@
   "description": "Plasma network running transfer-only MoreVP governed by LeapDAO",
   "consensus": "poa",
   "nodes": [
-    "https://testnet1.leapdao.org"
+    "wss://testnet-node1.leapdao.org:1443"
   ],
   "tokenFormUrl": "https://docs.google.com/forms/d/e/1FAIpQLSdFAezroU_uxvWWQmMxs_DWAasl5UwC_nQXIy0CtOfmgDVE2w/viewform?embedded=true",
   "exitMarketMaker": "https://cok43k06u1.execute-api.eu-west-1.amazonaws.com/v0/sellExit",

--- a/src/stores/web3/plasma.ts
+++ b/src/stores/web3/plasma.ts
@@ -14,7 +14,7 @@ export default class Web3Plasma {
     const plasmaProvider = CONFIG.nodes && CONFIG.nodes[0].url;
 
     this.instance = helpers.extendWeb3(
-      new Web3(new Web3.providers.HttpProvider(plasmaProvider))
+      new Web3(new Web3.providers.WebsocketProvider(plasmaProvider))
     );
 
     this.instance.eth.net


### PR DESCRIPTION
resolves https://github.com/leapdao/leap-node/issues/114

- [x] created ssl certificate for `*.leapdao.org` in eu-west region
- [x] configure AWS loadbalancers for https (port 443)
  - for testnet `https://testnet-node1.leapdao.org`
  - for mainnet `https://mainnet-node1.leapdao.org`
- [x] configure AWS loadbalancers for wss(port 1443)
  - for testnet `wss://testnet-node1.leapdao.org:1443`
  - for mainnet `wss://mainnet-node1.leapdao.org:1443`
- [x] included endpoints in bridge-ui configs
