### PR TITLE
fix: handle tokens without metadata

### DIFF
--- a/src/components/amountInput.tsx
+++ b/src/components/amountInput.tsx
@@ -88,7 +88,7 @@ export default class AmountInput extends React.Component<
       <Select
         value={color}
         style={{
-          width: this.token.isNft ? '120px !important' : '80px !import',
+          width: '80px',
         }}
         onChange={this.handleColorChange}
       >

--- a/src/stores/utils.ts
+++ b/src/stores/utils.ts
@@ -7,7 +7,7 @@
 
 import { EventLog } from 'web3/types';
 import Contract from 'web3/eth/contract';
-import { isNFT } from '../utils';
+import { isNFT, isNST } from '../utils';
 
 import { web3RootStore } from './web3/root';
 import { AccountStore } from './account';
@@ -20,6 +20,18 @@ function hexToAscii(hex) {
   }
   return result;
 }
+
+const defaultSymbol = (color, addr) => {
+  if (isNST(color)) {
+    return `NST${addr.substring(2, 5)}`;
+  }
+
+  if (isNFT(color)) {
+    return `NFT${addr.substring(2, 5)}`;
+  }
+
+  return `T${addr.substring(2, 5)}`;
+};
 
 const bytesTokenABI = [
   {
@@ -71,10 +83,12 @@ export const tokenInfo = (
 ): Promise<[string, string, string]> => {
   return Promise.all([
     tokenValue(token, 'symbol').catch(_ =>
-      token.options.address.substring(0, 5)
+      defaultSymbol(color, token.options.address)
     ),
     isNFT(color) ? Promise.resolve(0) : token.methods.decimals().call(),
-    tokenValue(token, 'name').catch(_ => `Token ${color}`),
+    tokenValue(token, 'name').catch(_ =>
+      defaultSymbol(color, token.options.address)
+    ),
   ]);
 };
 

--- a/src/stores/utils.ts
+++ b/src/stores/utils.ts
@@ -43,6 +43,9 @@ const bytesTokenABI = [
 ];
 
 const tokenValue = (token: Contract, method: string) => {
+  if (!token.methods[method]) {
+    return;
+  }
   return token.methods[method]()
     .call()
     .then(
@@ -64,9 +67,9 @@ export const tokenInfo = (
   color: number
 ): Promise<[string, string, string]> => {
   return Promise.all([
-    tokenValue(token, 'symbol'),
+    tokenValue(token, 'symbol') || token.options.address.substring(0, 5),
     isNFT(color) ? Promise.resolve(0) : token.methods.decimals().call(),
-    tokenValue(token, 'name'),
+    tokenValue(token, 'name') || `Token ${color}`,
   ]);
 };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export { range } from './range';
 export { toArray } from './toArray';
 export { txSuccess } from './txSuccess';
 export { nftDisplayValue, NFT_COLOR_BASE, isNFT } from './nft';
+export { nstDisplayValue, NST_COLOR_BASE, isNST } from './nst';
 
 export { KNOWN_NETWORKS } from './knownNetworks';
 

--- a/src/utils/nst.ts
+++ b/src/utils/nst.ts
@@ -1,0 +1,8 @@
+import { BigIntType } from 'jsbi-utils';
+
+export const NST_COLOR_BASE = 49153; // 2^15 + 1 + 2^14
+
+export const isNST = (color: number): boolean => color >= NST_COLOR_BASE;
+
+export const nstDisplayValue = (value: BigIntType): string =>
+  value.toString(10);


### PR DESCRIPTION
For tokens without metadata implemented, show first bytes of the address as a symbol and color as a name.
Resolves #208 