### PR TITLE
fix: show text input field for non-enumerable NFT

### DIFF
--- a/src/components/amountInput.tsx
+++ b/src/components/amountInput.tsx
@@ -104,10 +104,10 @@ export default class AmountInput extends React.Component<
   public render() {
     const { onColorChange, value, width = 250, plasma, ...rest } = this.props;
     const balance = plasma ? this.token.plasmaBalance : this.token.balance;
-
+    const enumerableNft = this.token.isNft && balance && balance[0];
     return (
       <Fragment>
-        {this.token.isNft && (
+        {enumerableNft && (
           <Fragment>
             <Form.Item>
               <Select
@@ -132,7 +132,7 @@ export default class AmountInput extends React.Component<
             )}
           </Fragment>
         )}
-        {!this.token.isNft && (
+        {!enumerableNft && (
           <Form.Item>
             <Input
               {...rest as any}

--- a/src/routes/wallet/deposit.tsx
+++ b/src/routes/wallet/deposit.tsx
@@ -191,7 +191,11 @@ export default class Deposit extends React.Component<DepositProps, any> {
           <Form onSubmit={this.handleSubmit} layout="inline">
             <div className="wallet-input">
               <AmountInput
-                placeholder="Amount to deposit"
+                placeholder={
+                  this.selectedToken.isNft
+                    ? 'Token id to deposit'
+                    : 'Amount to deposit'
+                }
                 value={this.value}
                 onChange={value => {
                   this.value = value;

--- a/src/stores/token.ts
+++ b/src/stores/token.ts
@@ -248,6 +248,11 @@ export class TokenStore extends ContractStore {
                   .call()
                   .then(v => bi(v))
               )
+              // assuming that exception happens due to missing `tokenOfOwnerByIndex`
+              // which is only for ERC721Enumerable. For non-enumerable NFTs let's return
+              // an array with proper size and no values
+            ).catch(
+              () => new Array<BigIntType>(parseInt(balance, 10))
             ) as Promise<BigIntType[]>;
           }
 


### PR DESCRIPTION
Because there is no other way to enter token id for those.

Resolves #222 