### PR TITLE
fix: make TokenValue to distinguish NFT balance and NFT token id

### DIFF
--- a/src/components/tokenValue.tsx
+++ b/src/components/tokenValue.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { observer } from 'mobx-react';
-import { BigIntType } from 'jsbi-utils';
+import { BigIntType, isBigInt } from 'jsbi-utils';
 import { tokensStore } from '../stores/tokens';
 
 interface TokenValueProps {
@@ -9,6 +9,24 @@ interface TokenValueProps {
   color: number;
   tokenLink?: boolean;
 }
+
+const nftValue = (value: BigIntType | BigIntType[]) => {
+  if (isBigInt(value)) {
+    return value.toString();
+  } else {
+    return (value as BigIntType[]).length;
+  }
+};
+
+const maybeSymbol = (token, value: BigIntType | BigIntType[]): string => {
+  // do not return symbol if showing NFT token id
+  if (token.isNft && isBigInt(value)) {
+    return;
+  }
+
+  // showing ERC20 value or NFT balance
+  return token.symbol;
+};
 
 const TokenValue: React.SFC<TokenValueProps> = ({
   value,
@@ -24,9 +42,9 @@ const TokenValue: React.SFC<TokenValueProps> = ({
   return (
     <React.Fragment>
       {token.isNft
-        ? (value as BigIntType[]).length
+        ? nftValue(value)
         : token.toTokens(value as BigIntType).toString()}{' '}
-      {!tokenLink && token.symbol}
+      {!tokenLink && maybeSymbol(token, value)}
       {tokenLink && (
         <Link to={`/explorer/address/${token.address}`}>{token.symbol}</Link>
       )}


### PR DESCRIPTION
For balance we want the number of tokens + symbol.
For token id we want just a value as string and no symbol.

Resolves #225 #223 