### PR TITLE
fix: fallback to color 0 if token selected in local storage is not exists

### DIFF
--- a/src/stores/selectedToken.ts
+++ b/src/stores/selectedToken.ts
@@ -1,16 +1,27 @@
-import { observable, computed, autorun } from 'mobx';
+import { observable, computed, autorun, when } from 'mobx';
 import autobind from 'autobind-decorator';
 import { tokensStore } from './tokens';
 
 const LS_KEY = 'wallet_color';
 
+const DEFAULT_COLOR = 0;
+
 export class SelectedTokenStore {
   @observable
-  public color = 0;
+  public color = DEFAULT_COLOR;
 
   constructor() {
-    this.color = Number(localStorage.getItem(LS_KEY) || 0);
+    this.color = Number(localStorage.getItem(LS_KEY) || DEFAULT_COLOR);
+
     autorun(this.save);
+    when(
+      () => tokensStore.list && tokensStore.list.length > 0,
+      () => {
+        if (!tokensStore.tokenForColor(this.color)) {
+          this.color = DEFAULT_COLOR;
+        }
+      }
+    );
   }
 
   @computed


### PR DESCRIPTION
Relevant only for situations when the network is changed, but the host is not. Mostly the case for local deployments (accessing via `localhost`)

Example:
1. I have color 1 selected on the previous testnet
2. I'm switching to the new testnet which has no color 1 yet.