### PR TITLE
feat: hide and clean migration message

### DIFF
--- a/src/components/appLayout.tsx
+++ b/src/components/appLayout.tsx
@@ -164,16 +164,10 @@ class AppLayout extends Component<AppLayoutProps, any> {
           </div>
         </Layout.Header>
 
-        {CONFIG.announceMigration && (
+        {CONFIG.announcement && (
           <Alert
-            message="Network will be revamped on 27 July 2019 14:00 UTC."
-            description={
-              <Fragment>
-                Do not transact after that date. See our{' '}
-                <a href="https://leapdao.org/blog/mainnet-revamp/">blog post</a>{' '}
-                for details
-              </Fragment>
-            }
+            message=""
+            description={<Fragment />}
             type="warning"
             showIcon
           />

--- a/src/config/mainnet/config.json
+++ b/src/config/mainnet/config.json
@@ -3,7 +3,7 @@
   "title": "LeapDAO Mainnet",
   "description": "Plasma network running transfer-only MoreVP governed by LeapDAO",
   "consensus": "poa",
-  "announceMigration": true,
+  "announcement": false,
   "bridgeDisabled": false,
   "nodes": ["wss://mainnet-node1.leapdao.org:1443"],
   "tokenFormUrl": "https://docs.google.com/forms/d/e/1FAIpQLSedGkkbHD6sdvdnnhJOg5bgLj0XsjU2caIsqyHQyzwmMjyZ9A/viewform?embedded=true",


### PR DESCRIPTION
I'm leaving the code in place, just so we can show stuff later if we need.
Don't mind to delete as well.