### PR TITLE
feat: use CAS-ready proofs, latest leap-core API, resolve deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ethereumjs-util": "6.0.0",
     "fork-ts-checker-webpack-plugin": "^0.4.15",
     "jsbi-utils": "^1.0.0",
-    "leap-core": "0.35.0",
+    "leap-core": "0.36.1",
     "mobx": "^5.0.3",
     "mobx-react": "^5.2.3",
     "prop-types": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ethereumjs-util": "6.0.0",
     "fork-ts-checker-webpack-plugin": "^0.4.15",
     "jsbi-utils": "^1.0.0",
-    "leap-core": "0.33.0",
+    "leap-core": "0.35.0",
     "mobx": "^5.0.3",
     "mobx-react": "^5.2.3",
     "prop-types": "^15.6.1",

--- a/src/components/watchtower.tsx
+++ b/src/components/watchtower.tsx
@@ -187,7 +187,9 @@ export default class Watchtower extends React.Component<WatchtowerProps, {}> {
     );
 
     const uTxos = await web3PlasmaStore.instance.getUnspentAll();
-    const addresses = await web3PlasmaStore.instance.getColors();
+    const addresses = Object.values(
+      await web3PlasmaStore.instance.getColors()
+    ).flat();
     const colors = await Promise.all(
       addresses.map(async addr => {
         return web3PlasmaStore.instance.getColor(addr);

--- a/src/components/watchtower.tsx
+++ b/src/components/watchtower.tsx
@@ -186,7 +186,7 @@ export default class Watchtower extends React.Component<WatchtowerProps, {}> {
       })
     );
 
-    const uTxos = await web3PlasmaStore.instance.getUnspentAll();
+    const uTxos = await web3PlasmaStore.instance.getUnspent();
     const addresses = Object.values(
       await web3PlasmaStore.instance.getColors()
     ).flat();

--- a/src/components/watchtower.tsx
+++ b/src/components/watchtower.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react';
-import { observable, reaction, autorun } from 'mobx';
+import { observable, reaction } from 'mobx';
 import { Input, Outpoint, Tx } from 'leap-core';
 import { observer } from 'mobx-react';
 import { Link } from 'react-router-dom';
@@ -138,7 +138,7 @@ export default class Watchtower extends React.Component<WatchtowerProps, {}> {
 
   constructor(props: WatchtowerProps) {
     super(props);
-    autorun(this.getData);
+    reaction(() => tokensStore.ready, () => this.getData());
   }
 
   @observable

--- a/src/stores/token.ts
+++ b/src/stores/token.ts
@@ -138,15 +138,12 @@ export class TokenStore extends ContractStore {
 
     const promiEvent = Web3PromiEvent();
     web3PlasmaStore.instance
-      .getUnspent(accountStore.address)
+      .getUnspent(accountStore.address, this.color)
       .then(unspent => {
         if (this.isNft) {
           let data;
           const { outpoint } = unspent.find(({ output }) => {
-            if (
-              Number(output.color) === Number(this.color) &&
-              equal(bi(output.value), bi(amount))
-            ) {
+            if (equal(bi(output.value), bi(amount))) {
               data = output.data;
               return true;
             } else {

--- a/src/stores/token.ts
+++ b/src/stores/token.ts
@@ -165,13 +165,13 @@ export class TokenStore extends ContractStore {
           );
         }
 
-        const inputs = helpers.calcInputs(
+        const inputs = Tx.calcInputs(
           unspent,
           accountStore.address,
           amount as any,
           this.color
         );
-        const outputs = helpers.calcOutputs(
+        const outputs = Tx.calcOutputs(
           unspent,
           inputs,
           accountStore.address,

--- a/src/stores/unspents.ts
+++ b/src/stores/unspents.ts
@@ -9,8 +9,6 @@ import { observable, reaction, computed, when } from 'mobx';
 import {
   Unspent,
   Tx,
-  Input,
-  Output,
   Outpoint,
   OutpointJSON,
   Type,
@@ -20,7 +18,7 @@ import {
 } from 'leap-core';
 import { bufferToHex, toBuffer } from 'ethereumjs-util';
 import autobind from 'autobind-decorator';
-import { add, bi, ZERO } from 'jsbi-utils';
+import { bi } from 'jsbi-utils';
 
 import { CONFIG } from '../config';
 import storage from '../utils/storage';
@@ -294,17 +292,15 @@ export class UnspentsStore {
 
   @autobind
   public consolidate(color: number) {
-    helpers
-      .consolidateUTXOs(this.listForColor(color))
-      .forEach(tx =>
-        tx
-          .signWeb3(web3InjectedStore.instance as any)
-          .then(signedTx =>
-            web3PlasmaStore.instance.eth.sendSignedTransaction(
-              signedTx.hex() as any
-            )
+    Tx.consolidateUTXOs(this.listForColor(color)).forEach(tx =>
+      tx
+        .signWeb3(web3InjectedStore.instance as any)
+        .then(signedTx =>
+          web3PlasmaStore.instance.eth.sendSignedTransaction(
+            signedTx.hex() as any
           )
-      );
+        )
+    );
   }
 }
 

--- a/src/stores/unspents.ts
+++ b/src/stores/unspents.ts
@@ -14,6 +14,7 @@ import {
   Type,
   LeapTransaction,
   helpers,
+  Period,
   Exit,
 } from 'leap-core';
 import { bufferToHex, toBuffer } from 'ethereumjs-util';
@@ -31,7 +32,7 @@ import { web3PlasmaStore } from './web3/plasma';
 import { tokensStore } from './tokens';
 import { web3InjectedStore } from './web3/injected';
 
-const { periodBlockRange, getYoungestInputTx, getProof } = helpers;
+const { getYoungestInputTx, getProof } = helpers;
 
 type UnspentWithTx = Unspent & {
   transaction: LeapTransaction;
@@ -89,7 +90,7 @@ export class UnspentsStore {
   @computed
   public get periodBlocksRange() {
     if (this.latestBlock) {
-      return periodBlockRange(this.latestBlock);
+      return Period.periodBlockRange(this.latestBlock);
     }
 
     return undefined;
@@ -262,7 +263,7 @@ export class UnspentsStore {
           unspent,
           sig: '',
           rawTx,
-          effectiveBlock: periodBlockRange(rawTx.blockNumber)[1],
+          effectiveBlock: Period.periodBlockRange(rawTx.blockNumber)[1],
           sigHashBuff: `0x${sigHashBuff.toString('hex')}`,
         };
         this.storePendingFastExits();

--- a/src/stores/unspents.ts
+++ b/src/stores/unspents.ts
@@ -128,13 +128,14 @@ export class UnspentsStore {
   }
 
   private exitDeposit(unspentDeposit: UnspentWithTx, signer: string) {
-    return getProof(
-      web3PlasmaStore.instance,
-      unspentDeposit.transaction,
-      0, // TODO: get this some-how
-      signer
-    ).then(txProof =>
-      exitHandlerStore.startExit([], txProof, unspentDeposit.outpoint.index, 0)
+    return getProof(web3PlasmaStore.instance, unspentDeposit.transaction).then(
+      txProof =>
+        exitHandlerStore.startExit(
+          [],
+          txProof,
+          unspentDeposit.outpoint.index,
+          0
+        )
     );
   }
 
@@ -151,8 +152,8 @@ export class UnspentsStore {
     getYoungestInputTx(web3PlasmaStore.instance, tx)
       .then(inputTx =>
         Promise.all([
-          getProof(web3PlasmaStore.instance, unspent.transaction, 0, signer),
-          getProof(web3PlasmaStore.instance, inputTx.tx, 0, signer),
+          getProof(web3PlasmaStore.instance, unspent.transaction),
+          getProof(web3PlasmaStore.instance, inputTx.tx),
           inputTx.index,
         ])
       )
@@ -210,8 +211,8 @@ export class UnspentsStore {
       ])
     );
     return Promise.all([
-      getProof(web3PlasmaStore.instance, rawTx, 0, signer),
-      getProof(web3PlasmaStore.instance, unspent.transaction, 0, signer),
+      getProof(web3PlasmaStore.instance, rawTx),
+      getProof(web3PlasmaStore.instance, unspent.transaction),
       0,
     ]).then(([txProof, inputProof, inputIndex]) => {
       // call api

--- a/src/utils/abis/exitHandler.ts
+++ b/src/utils/abis/exitHandler.ts
@@ -5,6 +5,24 @@ export default [
     constant: false,
     inputs: [
       {
+        name: '_token',
+        type: 'address',
+      },
+      {
+        name: '_type',
+        type: 'uint256',
+      },
+    ],
+    name: 'registerToken',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
         name: '_amountOrTokenId',
         type: 'uint256',
       },
@@ -20,20 +38,6 @@ export default [
     type: 'function',
   },
   {
-    constant: false,
-    inputs: [
-      {
-        name: '_token',
-        type: 'address',
-      },
-    ],
-    name: 'registerNST',
-    outputs: [],
-    payable: false,
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
     constant: true,
     inputs: [],
     name: 'depositCount',
@@ -41,25 +45,6 @@ export default [
       {
         name: '',
         type: 'uint32',
-      },
-    ],
-    payable: false,
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    constant: true,
-    inputs: [
-      {
-        name: '',
-        type: 'bytes32',
-      },
-    ],
-    name: 'exitsTokenData',
-    outputs: [
-      {
-        name: '',
-        type: 'bytes32',
       },
     ],
     payable: false,
@@ -133,6 +118,20 @@ export default [
   {
     constant: true,
     inputs: [],
+    name: 'implementation',
+    outputs: [
+      {
+        name: 'impl',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
     name: 'nstExitCounter',
     outputs: [
       {
@@ -142,24 +141,6 @@ export default [
     ],
     payable: false,
     stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    constant: false,
-    inputs: [
-      {
-        name: '_token',
-        type: 'address',
-      },
-      {
-        name: '_isERC721',
-        type: 'bool',
-      },
-    ],
-    name: 'registerToken',
-    outputs: [],
-    payable: false,
-    stateMutability: 'nonpayable',
     type: 'function',
   },
   {
@@ -386,45 +367,6 @@ export default [
     type: 'function',
   },
   {
-    constant: true,
-    inputs: [
-      {
-        name: '',
-        type: 'bytes32',
-      },
-    ],
-    name: 'exits',
-    outputs: [
-      {
-        name: 'amount',
-        type: 'uint256',
-      },
-      {
-        name: 'color',
-        type: 'uint16',
-      },
-      {
-        name: 'owner',
-        type: 'address',
-      },
-      {
-        name: 'finalized',
-        type: 'bool',
-      },
-      {
-        name: 'priorityTimestamp',
-        type: 'uint32',
-      },
-      {
-        name: 'stake',
-        type: 'uint256',
-      },
-    ],
-    payable: false,
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
     anonymous: false,
     inputs: [
       {
@@ -451,51 +393,15 @@ export default [
         indexed: false,
         name: 'amount',
         type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'periodRoot',
+        type: 'bytes32',
       },
     ],
     name: 'ExitStarted',
     type: 'event',
-    signature:
-      '0xaace06690e02011b548d8c5a74e1a678833d4136a56e657909fc6354bfb7c31f',
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        name: 'txHash',
-        type: 'bytes32',
-      },
-      {
-        indexed: true,
-        name: 'outIndex',
-        type: 'uint8',
-      },
-      {
-        indexed: true,
-        name: 'color',
-        type: 'uint256',
-      },
-      {
-        indexed: false,
-        name: 'exitor',
-        type: 'address',
-      },
-      {
-        indexed: false,
-        name: 'amount',
-        type: 'uint256',
-      },
-      {
-        indexed: false,
-        name: 'data',
-        type: 'bytes32',
-      },
-    ],
-    name: 'ExitStartedV2',
-    type: 'event',
-    signature:
-      '0x30924909ab00e149ea3c4b2ca611cbd244a3ac033163919000ccedf093fb4bf4',
   },
   {
     anonymous: false,
@@ -523,8 +429,6 @@ export default [
     ],
     name: 'NewDeposit',
     type: 'event',
-    signature:
-      '0x3fb288e5672e5fbbac19c54a77d8c562a521b069b922e16736f69e648ceb13a3',
   },
   {
     anonymous: false,
@@ -537,8 +441,6 @@ export default [
     ],
     name: 'MinGasPrice',
     type: 'event',
-    signature:
-      '0x85feea100eda69e1c4fe1b228ed4d7229f3e9e9ebf7d30893d71de8165c46abb',
   },
   {
     anonymous: false,
@@ -571,8 +473,6 @@ export default [
     ],
     name: 'NewDepositV2',
     type: 'event',
-    signature:
-      '0xfc7d4a724aae4a4fa0536a988ae3a4e31bfeffd022c2aa2a5d5eef40758b8ac4',
   },
   {
     anonymous: false,
@@ -590,8 +490,53 @@ export default [
     ],
     name: 'NewToken',
     type: 'event',
-    signature:
-      '0xfe74dea79bde70d1990ddb655bac45735b14f495ddc508cfab80b7729aa9d668',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_utxoId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'exits',
+    outputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        name: 'color',
+        type: 'uint16',
+      },
+      {
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        name: 'finalized',
+        type: 'bool',
+      },
+      {
+        name: 'priorityTimestamp',
+        type: 'uint32',
+      },
+      {
+        name: 'stake',
+        type: 'uint256',
+      },
+      {
+        name: 'tokenData',
+        type: 'bytes32',
+      },
+      {
+        name: 'periodRoot',
+        type: 'bytes32',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
   },
   {
     constant: false,
@@ -730,6 +675,10 @@ export default [
         name: '_inputIndex',
         type: 'uint8',
       },
+      {
+        name: 'challenger',
+        type: 'address',
+      },
     ],
     name: 'challengeExit',
     outputs: [],
@@ -755,6 +704,10 @@ export default [
       {
         name: '_inputIndex',
         type: 'uint8',
+      },
+      {
+        name: 'challenger',
+        type: 'address',
       },
     ],
     name: 'challengeYoungestInput',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5093,10 +5093,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@0.35.0:
-  version "0.35.0"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.35.0.tgz#89d5a470a37a355a843647840a3f6ffdd5a99f79"
-  integrity sha512-q8VKCXtbFVCUEkAbQp4YE+8aZ8lxXc9zOQGxwZ2M/6eRysXVzloywcD7/T2zJG+nvaw4xg7+kGxgaDEiaZrORA==
+leap-core@0.36.1:
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.36.1.tgz#c19713d60eac8e9bfcc2880524fed28c8db6341f"
+  integrity sha512-QP+z1oWHI7FaPw/hjqDU4KTwq18tvCOZ7ZtsviiGRhOYaMnUevzc+Yu6itmBX1eLwjs1MSnJyJVp4ulo2qDySg==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5093,9 +5093,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@0.33.0:
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.33.0.tgz#5ee36f4eb46746a2edd3af8a03bc17ba0e644bcd"
+leap-core@0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.35.0.tgz#89d5a470a37a355a843647840a3f6ffdd5a99f79"
+  integrity sha512-q8VKCXtbFVCUEkAbQp4YE+8aZ8lxXc9zOQGxwZ2M/6eRysXVzloywcD7/T2zJG+nvaw4xg7+kGxgaDEiaZrORA==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"


### PR DESCRIPTION
- Use newer `getProof` from leap-core supporting CAS-data
- Using `Tx.consolidateUTXOs` instead of deprecated `helpers.consolidateUTXOs`.
- use latest `getColors()` api
- update ExitHandler ABI so that watchtower is able to catch up ExitStarted events

Requires https://github.com/leapdao/leap-core/pull/135, https://github.com/leapdao/leap-core/pull/134, https://github.com/leapdao/leap-core/pull/151

Resolves #245 

Can be tested using local env running node https://github.com/leapdao/leap-node/pull/318