### PR TITLE
feat(token governance): show proposals in new UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "react": "16.8.1",
     "react-dom": "16.8.1",
     "react-iframe": "^1.3.3",
+    "react-markdown": "^4.3.1",
     "react-responsive": "^4.1.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/src/components/appLayout.tsx
+++ b/src/components/appLayout.tsx
@@ -17,7 +17,6 @@ import { Dropdown, Icon, Layout, Menu, Spin, Button, Alert } from 'antd';
 import { CONFIG } from '../config';
 import AppLogo from './appLogo';
 import Message from './message';
-import TokenValue from './tokenValue';
 
 import '../style.css';
 
@@ -77,9 +76,15 @@ class AppLayout extends Component<AppLayoutProps, any> {
         mode={horizontal ? 'horizontal' : 'vertical'}
         style={{ lineHeight: '64px', width: '100%' }}
       >
-        <Menu.Item key="governance">
-          <Link to="/governance">Governance</Link>
-        </Menu.Item>
+        <Menu.SubMenu title="Governance">
+          <Menu.Item key="governance/plasma">
+            <Link to="/governance/plasma">Plasma Network</Link>
+          </Menu.Item>
+          <Menu.Item key="governance/token">
+            <Link to="/governance/token">Token</Link>
+          </Menu.Item>
+        </Menu.SubMenu>
+
         {CONFIG.consensus !== 'poa' && (
           <Menu.Item key="slots">
             <Link to={`/slots`}>Slots auction</Link>

--- a/src/components/governance/proposalForm.tsx
+++ b/src/components/governance/proposalForm.tsx
@@ -18,6 +18,7 @@ import {
   ProposalLifecycle,
 } from '../../stores/governance/proposalStore';
 
+const { Fragment } = React;
 const { TextArea } = Input;
 
 interface ProposalFormProps {
@@ -126,7 +127,17 @@ export default class ProposalForm extends React.Component<
               onChange={e => (this.title = e.target.value)}
             />
           </Form.Item>
-          <Form.Item label="Description">
+          <Form.Item
+            label="Description"
+            help={
+              <Fragment>
+                <a href="https://commonmark.org/help/" target="_blank">
+                  Markdown
+                </a>{' '}
+                is supported
+              </Fragment>
+            }
+          >
             <TextArea
               name="description"
               value={this.description}

--- a/src/components/governance/proposalForm.tsx
+++ b/src/components/governance/proposalForm.tsx
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2020-present, Leap DAO (leapdao.org)
+ *
+ * This source code is licensed under the GNU GENERAL PUBLIC LICENSE Version 3
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import { Spin, Form, Button, Input, notification, Icon } from 'antd';
+import { observable, computed } from 'mobx';
+import autobind from 'autobind-decorator';
+import { observer } from 'mobx-react';
+import { EventEmitter } from 'events';
+import * as React from 'react';
+
+import { Proposal } from '../../stores/governance/proposal';
+import {
+  proposalStore,
+  ProposalLifecycle,
+} from '../../stores/governance/proposalStore';
+
+const { TextArea } = Input;
+
+interface ProposalFormProps {
+  onCancel?: () => void;
+  onSuccess?: (proposal: Proposal) => void;
+}
+
+interface ProposalFormState {}
+
+@observer
+export default class ProposalForm extends React.Component<
+  ProposalFormProps,
+  ProposalFormState
+> {
+  @observable
+  private title: string;
+
+  @observable
+  private description: string;
+
+  @observable
+  private submitting: boolean;
+
+  @computed
+  private get canSubmit(): boolean {
+    return !!this.title && !!this.description && !this.submitting;
+  }
+
+  @computed
+  private get canEdit(): boolean {
+    return !this.submitting;
+  }
+
+  @autobind
+  private onCancel(): void {
+    this.title = '';
+    this.description = '';
+    this.submitting = false;
+    this.props.onCancel();
+  }
+
+  private progressIndicator(): EventEmitter {
+    const progress = new EventEmitter();
+    progress
+      .on(ProposalLifecycle.IPFS_UPLOAD, ({ title }) => {
+        notification.open({
+          key: `ipfsUpload${title}`,
+          message: 'Uploading proposal to IPFS...',
+          icon: <Spin />,
+          duration: 0,
+          description: <i>{title}</i>,
+        });
+      })
+      .on(ProposalLifecycle.SUBMIT_TO_CONTRACT, ({ title }) => {
+        notification.close(`ipfsUpload${title}`);
+      })
+      .on(ProposalLifecycle.CREATED, ({ title }) => {
+        this.description = '';
+        this.title = '';
+        notification.open({
+          key: `proposal:create:success:${title}`,
+          message: 'Proposal registered',
+          icon: <Icon type="check-circle" style={{ color: 'green' }} />,
+          duration: 2,
+          description: <i>{title}</i>,
+        });
+      })
+      .on(ProposalLifecycle.FAILED_TO_CREATE, ({ title }) => {
+        notification.open({
+          key: `proposal:create:failed:${title}`,
+          message: 'Failed to create proposal',
+          icon: <Icon type="close-circle" style={{ color: 'red' }} />,
+          duration: 2,
+          description: <i>{title}</i>,
+        });
+      });
+    return progress;
+  }
+
+  @autobind
+  public async sendToContract() {
+    this.submitting = true;
+
+    console.log('title:', this.title, 'description:', this.description);
+
+    const proposal = await proposalStore.create(
+      this.title,
+      this.description,
+      this.progressIndicator()
+    );
+
+    this.props.onSuccess(proposal);
+    this.submitting = false;
+  }
+
+  public render() {
+    return (
+      <Spin size="large" spinning={!!this.submitting}>
+        <Form>
+          <Form.Item label="Title">
+            <Input
+              name="title"
+              value={this.title}
+              placeholder="Give your proposal a Title"
+              disabled={!this.canEdit}
+              onChange={e => (this.title = e.target.value)}
+            />
+          </Form.Item>
+          <Form.Item label="Description">
+            <TextArea
+              name="description"
+              value={this.description}
+              rows={4}
+              placeholder="Describe what your proposal is about..."
+              disabled={!this.canEdit}
+              onChange={e => (this.description = e.target.value)}
+            />
+          </Form.Item>
+          <Form.Item>
+            <Button
+              type="primary"
+              onClick={this.sendToContract}
+              disabled={!this.canSubmit}
+            >
+              Submit Proposal
+            </Button>{' '}
+            <Button onClick={this.onCancel}>Cancel</Button>
+          </Form.Item>
+        </Form>
+      </Spin>
+    );
+  }
+}

--- a/src/components/governance/proposalListItem.tsx
+++ b/src/components/governance/proposalListItem.tsx
@@ -8,6 +8,7 @@
 import { Icon, List } from 'antd';
 import { observer } from 'mobx-react';
 import * as React from 'react';
+import * as ReactMarkdown from 'react-markdown';
 
 import { Proposal } from '../../stores/governance/proposal';
 
@@ -33,14 +34,16 @@ export default class ProposalListItem extends React.Component<
     const { proposal } = this.props;
     return (
       <List.Item
-        className="governanceProposal"
+        className="token-governance-proposal with-markdown"
         actions={[
           <IconText type="like-o" text={proposal.yesVotes} />,
           <IconText type="dislike-o" text={proposal.noVotes} />,
         ]}
       >
-        <List.Item.Meta title={proposal.title} />
-        {proposal.description}
+        <List.Item.Meta
+          title={proposal.title}
+          description={<ReactMarkdown source={proposal.description} />}
+        />
       </List.Item>
     );
   }

--- a/src/components/governance/proposalListItem.tsx
+++ b/src/components/governance/proposalListItem.tsx
@@ -11,6 +11,13 @@ import * as React from 'react';
 
 import { Proposal } from '../../stores/governance/proposal';
 
+const IconText = ({ type, text }) => (
+  <span>
+    <Icon type={type} style={{ marginRight: 8 }} />
+    {text}
+  </span>
+);
+
 interface ProposalListItemProps {
   proposal: Proposal;
 }
@@ -27,23 +34,12 @@ export default class ProposalListItem extends React.Component<
     return (
       <List.Item
         className="governanceProposal"
-        extra={
-          <div
-            style={{
-              minWidth: '190px',
-              textAlign: 'center',
-              padding: '16px',
-            }}
-          >
-            <Icon type="like" style={{ fontSize: 24, width: '2rem' }} />
-            <Icon type="dislike" style={{ fontSize: 24, width: '2rem' }} />
-          </div>
-        }
+        actions={[
+          <IconText type="like-o" text={proposal.yesVotes} />,
+          <IconText type="dislike-o" text={proposal.noVotes} />,
+        ]}
       >
-        <List.Item.Meta
-          title={proposal.title}
-          description={'created by:' + proposal.creator}
-        />
+        <List.Item.Meta title={proposal.title} />
         {proposal.description}
       </List.Item>
     );

--- a/src/components/governance/proposalListItem.tsx
+++ b/src/components/governance/proposalListItem.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2020-present, Leap DAO (leapdao.org)
+ *
+ * This source code is licensed under the GNU GENERAL PUBLIC LICENSE Version 3
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+import { Icon, List } from 'antd';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+
+import { Proposal } from '../../stores/governance/proposal';
+
+interface ProposalListItemProps {
+  proposal: Proposal;
+}
+
+interface ProposalListItemState {}
+
+@observer
+export default class ProposalListItem extends React.Component<
+  ProposalListItemProps,
+  ProposalListItemState
+> {
+  public render() {
+    const { proposal } = this.props;
+    return (
+      <List.Item
+        className="governanceProposal"
+        extra={
+          <div
+            style={{
+              minWidth: '190px',
+              textAlign: 'center',
+              padding: '16px',
+            }}
+          >
+            <Icon type="like" style={{ fontSize: 24, width: '2rem' }} />
+            <Icon type="dislike" style={{ fontSize: 24, width: '2rem' }} />
+          </div>
+        }
+      >
+        <List.Item.Meta
+          title={proposal.title}
+          description={'created by:' + proposal.creator}
+        />
+        {proposal.description}
+      </List.Item>
+    );
+  }
+}

--- a/src/components/watchtower.tsx
+++ b/src/components/watchtower.tsx
@@ -151,9 +151,7 @@ export default class Watchtower extends React.Component<WatchtowerProps, {}> {
         reaction(() => bridgeStore.address, resolve)
       );
     }
-    const fromBlock = await bridgeStore.contract.methods
-      .genesisBlockNumber()
-      .call();
+    const fromBlock = await bridgeStore.genesisBlockNumber;
     const events = await exitHandlerStore.contract.getPastEvents(
       'ExitStarted',
       {

--- a/src/config/testnet/config.json
+++ b/src/config/testnet/config.json
@@ -9,5 +9,5 @@
   "tokenFaucet": "https://jw98dxp219.execute-api.eu-west-1.amazonaws.com/testnet",
   "denverFaucet": "https://jw98dxp219.execute-api.eu-west-1.amazonaws.com/testnet/address",
   "txStorage": "https://57scxrw3ql.execute-api.eu-west-1.amazonaws.com/v0",
-  "tokenGovernanceAddress": "0x3cc955f91d645b4250f6070a8b7d71365662776f"
+  "tokenGovernanceAddress": "0x858d6D9C6E5900BA06ed9898d545C890b660dE35"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,8 @@ import Wallet from './routes/wallet';
 import Slots from './routes/slots';
 import RegisterToken from './routes/registerToken';
 import Status from './routes/status';
-import Governance from './routes/governance';
+import PlasmaGovernance from './routes/governance/plasma';
+import TokenGovernance from './routes/governance/token';
 
 const Home = require('./config/' + CONFIG_NAME + '/home.tsx').default;
 
@@ -32,7 +33,9 @@ ReactDOM.render(
     <Fragment>
       <TxNotification />
       <Route path="/" exact component={Home} />
-      <Route path="/governance" component={Governance} />
+      <Route path="/governance" exact component={PlasmaGovernance} />
+      <Route path="/governance/plasma" component={PlasmaGovernance} />
+      <Route path="/governance/token" component={TokenGovernance} />
       <Route path="/slots" component={Slots} />
       <Route path="/:bridgeAddr(0x[0-9a-fA-f]{40})" exact component={Slots} />
       <Route path="/registerToken" exact component={RegisterToken} />

--- a/src/routes/governance/plasma.tsx
+++ b/src/routes/governance/plasma.tsx
@@ -7,17 +7,16 @@
 
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { List, Collapse, Icon, Divider, Row } from 'antd';
+import { List, Collapse, Icon } from 'antd';
 import TimeAgo from 'react-timeago';
 
-import Web3SubmitWarning from '../components/web3SubmitWarning';
-import TokenGovernance from './tokenGovernance';
+import Web3SubmitWarning from '../../components/web3SubmitWarning';
 
-import AppLayout from '../components/appLayout';
-import EtherscanLink from '../components/etherscanLink';
-import { shortenHex } from '../utils';
+import AppLayout from '../../components/appLayout';
+import EtherscanLink from '../../components/etherscanLink';
+import { shortenHex } from '../../utils';
 import { Button } from 'antd';
-import { governanceContractStore } from '../stores/governanceContract';
+import { governanceContractStore } from '../../stores/governanceContract';
 
 const { Fragment } = React;
 
@@ -130,55 +129,47 @@ export default class Governance extends React.Component<GovernanceProps, any> {
       finalize,
     } = governanceContract;
     return (
-      <AppLayout section="governance">
-        <Row gutter={16}>
-          <h1>Minimum Viable Governance</h1>
-          <Web3SubmitWarning />
+      <AppLayout section="governance/plasma">
+        <h1>Leap Network Governance</h1>
+        <Web3SubmitWarning />
 
-          {noGovernance && <span>No governance set up</span>}
+        {noGovernance && <span>No governance set up</span>}
 
-          {proposals && proposals.length === 0 && <span>No proposals yet</span>}
-          {proposals && proposals.length > 0 && (
-            <Fragment>
-              <h1>Proposals</h1>
-              <List
-                itemLayout="vertical"
-                size="small"
-                dataSource={proposals}
-                renderItem={item => (
-                  <List.Item
-                    className="governanceProposal"
-                    extra={
-                      <div
-                        style={{
-                          minWidth: '190px',
-                          textAlign: 'center',
-                          padding: '16px',
-                        }}
-                      >
-                        {renderDate(item)}
-                      </div>
-                    }
-                  >
-                    <List.Item.Meta title={item.summaryStr} />
-                    {this.renderContent(item)}
-                  </List.Item>
-                )}
-              />
-            </Fragment>
-          )}
-          {canFinalize && (
-            <div style={{ paddingTop: '1rem' }}>
-              <Button onClick={finalize}>Finalize proposals</Button>
-            </div>
-          )}
-        </Row>
-        <Row>
-          <Divider />
-        </Row>
-        <Row gutter={16}>
-          <TokenGovernance />
-        </Row>
+        {proposals && proposals.length === 0 && <span>No proposals yet</span>}
+        {proposals && proposals.length > 0 && (
+          <Fragment>
+            <h1>Proposals</h1>
+            <List
+              itemLayout="vertical"
+              size="small"
+              dataSource={proposals}
+              renderItem={item => (
+                <List.Item
+                  className="governanceProposal"
+                  extra={
+                    <div
+                      style={{
+                        minWidth: '190px',
+                        textAlign: 'center',
+                        padding: '16px',
+                      }}
+                    >
+                      {renderDate(item)}
+                    </div>
+                  }
+                >
+                  <List.Item.Meta title={item.summaryStr} />
+                  {this.renderContent(item)}
+                </List.Item>
+              )}
+            />
+          </Fragment>
+        )}
+        {canFinalize && (
+          <div style={{ paddingTop: '1rem' }}>
+            <Button onClick={finalize}>Finalize proposals</Button>
+          </div>
+        )}
       </AppLayout>
     );
   }

--- a/src/routes/governance/token.tsx
+++ b/src/routes/governance/token.tsx
@@ -14,15 +14,15 @@ import {
 } from 'antd';
 
 import autobind from 'autobind-decorator';
-import Web3SubmitWarning from '../components/web3SubmitWarning';
+import AppLayout from '../../components/appLayout';
+import Web3SubmitWarning from '../../components/web3SubmitWarning';
 import {
   proposalStore,
   ProposalLifecycle,
-} from '../stores/governance/proposalStore';
+} from '../../stores/governance/proposalStore';
 import { EventEmitter } from 'events';
 
 const { TextArea } = Input;
-const { Fragment } = React;
 const { TabPane } = Tabs;
 
 @observer
@@ -100,7 +100,7 @@ export default class TokenGovernance extends React.Component {
 
   public render() {
     return (
-      <Fragment>
+      <AppLayout section="governance/token">
         <h1>Token Governance</h1>
         <Web3SubmitWarning />
 
@@ -159,7 +159,7 @@ export default class TokenGovernance extends React.Component {
             </Spin>
           </TabPane>
         </Tabs>
-      </Fragment>
+      </AppLayout>
     );
   }
 }

--- a/src/routes/governance/token.tsx
+++ b/src/routes/governance/token.tsx
@@ -11,6 +11,7 @@ import {
   Spin,
   Icon,
   notification,
+  List,
 } from 'antd';
 
 import autobind from 'autobind-decorator';
@@ -20,6 +21,7 @@ import {
   proposalStore,
   ProposalLifecycle,
 } from '../../stores/governance/proposalStore';
+import { Proposal } from '../../stores/governance/proposal';
 import { EventEmitter } from 'events';
 
 const { TextArea } = Input;
@@ -98,67 +100,96 @@ export default class TokenGovernance extends React.Component {
     this.submitting = false;
   }
 
+  @autobind
+  private renderProposal(proposal: Proposal) {
+    return (
+      <List.Item
+        className="governanceProposal"
+        extra={
+          <div
+            style={{
+              minWidth: '190px',
+              textAlign: 'center',
+              padding: '16px',
+            }}
+          >
+            <Icon type="like" style={{ fontSize: 24, width: '2rem' }} />
+            <Icon type="dislike" style={{ fontSize: 24, width: '2rem' }} />
+          </div>
+        }
+      >
+        <List.Item.Meta
+          title={proposal.title}
+          description={'created by:' + proposal.creator}
+        />
+        {proposal.description}
+      </List.Item>
+    );
+  }
+
   public render() {
     return (
       <AppLayout section="governance/token">
         <h1>Token Governance</h1>
         <Web3SubmitWarning />
-
-        <Tabs defaultActiveKey="1" type="card">
-          <TabPane tab="Open for voting" key="1">
-            Content of Tab d1
-          </TabPane>
-          <TabPane tab="Ready for processing" key="2">
-            Content of Tab 2
-          </TabPane>
-          <TabPane tab="Finalize proposals" key="3">
-            Content of Tab 3
-          </TabPane>
-          <TabPane tab="Submit a proposal" key="4">
-            <Spin size="large" spinning={!!this.submitting}>
-              <Form>
-                <Row gutter={28}>
-                  <Col span={10}>
-                    <h3>Proposal Title</h3>
-                    <Form.Item>
-                      <Input
-                        name="title"
-                        value={this.title}
-                        placeholder="Give your proposal a Title"
-                        disabled={!this.canEdit}
-                        onChange={e => (this.title = e.target.value)}
-                      />
-                    </Form.Item>
-                  </Col>
-                </Row>
-                <Row>
-                  <Col span={10}>
-                    <h3>Proposal Description</h3>
-                    <Form.Item>
-                      <TextArea
-                        name="description"
-                        value={this.description}
-                        rows={4}
-                        placeholder="Describe what your proposal is about..."
-                        disabled={!this.canEdit}
-                        onChange={e => (this.description = e.target.value)}
-                      />
-                    </Form.Item>
-                  </Col>
-                </Row>
+        <Button type="primary">Create new proposal</Button>
+        &nbsp;
+        <Button>Finalize proposals</Button>
+        {proposalStore.proposals ? (
+          <List
+            itemLayout="vertical"
+            size="small"
+            dataSource={proposalStore.proposals}
+            renderItem={this.renderProposal}
+          />
+        ) : (
+          <div className="tokens-loading">
+            <Spin />
+            Loading proposals...
+          </div>
+        )}
+        <Spin size="large" spinning={!!this.submitting}>
+          <Form>
+            <Row gutter={28}>
+              <Col span={10}>
+                <h3>Proposal Title</h3>
                 <Form.Item>
-                  <Button
-                    type="primary"
-                    onClick={this.sendToContract}
-                    disabled={!this.canSubmit}
-                  >
-                    Submit Proposal
-                  </Button>
+                  <Input
+                    name="title"
+                    value={this.title}
+                    placeholder="Give your proposal a Title"
+                    disabled={!this.canEdit}
+                    onChange={e => (this.title = e.target.value)}
+                  />
                 </Form.Item>
-              </Form>
-            </Spin>
-          </TabPane>
-        </Tabs>
+              </Col>
+            </Row>
+            <Row>
+              <Col span={10}>
+                <h3>Proposal Description</h3>
+                <Form.Item>
+                  <TextArea
+                    name="description"
+                    value={this.description}
+                    rows={4}
+                    placeholder="Describe what your proposal is about..."
+                    disabled={!this.canEdit}
+                    onChange={e => (this.description = e.target.value)}
+                  />
+                </Form.Item>
+              </Col>
+            </Row>
+            <Form.Item>
+              <Button
+                type="primary"
+                onClick={this.sendToContract}
+                disabled={!this.canSubmit}
+              >
+                Submit Proposal
+              </Button>
+            </Form.Item>
+          </Form>
+        </Spin>
       </AppLayout>
     );
   }

--- a/src/routes/governance/token.tsx
+++ b/src/routes/governance/token.tsx
@@ -1,32 +1,15 @@
 import * as React from 'react';
 import { observable, computed } from 'mobx';
 import { observer } from 'mobx-react';
-import {
-  Button,
-  Form,
-  Input,
-  Row,
-  Col,
-  Spin,
-  Icon,
-  notification,
-  List,
-  Radio,
-} from 'antd';
+import { Button, Spin, List, Radio, Card } from 'antd';
 
-import autobind from 'autobind-decorator';
-import AppLayout from '../../components/appLayout';
+import { proposalStore } from '../../stores/governance/proposalStore';
+import ProposalForm from '../../components/governance/proposalForm';
+import ProposalListItem from '../../components/governance/proposal';
 import Web3SubmitWarning from '../../components/web3SubmitWarning';
-import {
-  proposalStore,
-  ProposalLifecycle,
-} from '../../stores/governance/proposalStore';
 import { Proposal } from '../../stores/governance/proposal';
-import { EventEmitter } from 'events';
-
-const { TextArea } = Input;
-
-type ProposalFilter = (proposal: Proposal) => boolean;
+import AppLayout from '../../components/appLayout';
+import autobind from 'autobind-decorator';
 
 const filters = {
   inprogress: (proposal: Proposal) => !proposal.isMature(),
@@ -38,78 +21,10 @@ const filters = {
 @observer
 export default class TokenGovernance extends React.Component {
   @observable
-  private title: string;
-
-  @observable
-  private description: string;
-
-  @observable
-  private submitting: boolean;
-
-  @observable
   private filterBy: string = 'inprogress';
 
-  @computed
-  private get canSubmit(): boolean {
-    return !!this.title && !!this.description && !this.submitting;
-  }
-
-  @computed
-  private get canEdit(): boolean {
-    return !this.submitting;
-  }
-
-  private progressIndicator(): EventEmitter {
-    const progress = new EventEmitter();
-    progress
-      .on(ProposalLifecycle.IPFS_UPLOAD, ({ title }) => {
-        notification.open({
-          key: `ipfsUpload${title}`,
-          message: 'Uploading proposal to IPFS...',
-          icon: <Spin />,
-          duration: 0,
-          description: <i>{title}</i>,
-        });
-      })
-      .on(ProposalLifecycle.SUBMIT_TO_CONTRACT, ({ title }) => {
-        notification.close(`ipfsUpload${title}`);
-      })
-      .on(ProposalLifecycle.CREATED, ({ title }) => {
-        this.description = '';
-        this.title = '';
-        notification.open({
-          key: `proposal:create:success:${title}`,
-          message: 'Proposal registered',
-          icon: <Icon type="check-circle" style={{ color: 'green' }} />,
-          duration: 2,
-          description: <i>{title}</i>,
-        });
-      })
-      .on(ProposalLifecycle.FAILED_TO_CREATE, ({ title }) => {
-        notification.open({
-          key: `proposal:create:failed:${title}`,
-          message: 'Failed to create proposal',
-          icon: <Icon type="close-circle" style={{ color: 'red' }} />,
-          duration: 2,
-          description: <i>{title}</i>,
-        });
-      });
-    return progress;
-  }
-
-  @autobind
-  public async sendToContract() {
-    this.submitting = true;
-
-    console.log('title:', this.title, 'description:', this.description);
-
-    await proposalStore.create(
-      this.title,
-      this.description,
-      this.progressIndicator()
-    );
-    this.submitting = false;
-  }
+  @observable
+  private showForm: boolean;
 
   @computed
   private get proposals() {
@@ -117,30 +32,8 @@ export default class TokenGovernance extends React.Component {
   }
 
   @autobind
-  private renderProposal(proposal: Proposal) {
-    return (
-      <List.Item
-        className="governanceProposal"
-        extra={
-          <div
-            style={{
-              minWidth: '190px',
-              textAlign: 'center',
-              padding: '16px',
-            }}
-          >
-            <Icon type="like" style={{ fontSize: 24, width: '2rem' }} />
-            <Icon type="dislike" style={{ fontSize: 24, width: '2rem' }} />
-          </div>
-        }
-      >
-        <List.Item.Meta
-          title={proposal.title}
-          description={'created by:' + proposal.creator}
-        />
-        {proposal.description}
-      </List.Item>
-    );
+  private hideProposalForm() {
+    this.showForm = false;
   }
 
   public render() {
@@ -157,16 +50,30 @@ export default class TokenGovernance extends React.Component {
             <h1>Token Governance Proposals</h1>
           </div>
           <div style={{ display: 'flex', alignItems: 'center' }}>
-            <Button key="finalize">Finalize</Button>
+            <Button key="finalize" disabled={true}>
+              Finalize
+            </Button>
             <Button
               key="createProposals"
               type="primary"
               style={{ marginLeft: '0.5rem' }}
+              onClick={() => (this.showForm = !this.showForm)}
             >
               Create new proposal
             </Button>
           </div>
         </div>
+        <Card
+          title="New proposal"
+          bordered={true}
+          style={{ marginBottom: '1rem' }}
+          hidden={!this.showForm}
+        >
+          <ProposalForm
+            onSuccess={this.hideProposalForm}
+            onCancel={this.hideProposalForm}
+          />
+        </Card>
         <Web3SubmitWarning />
         Show:{' '}
         <Radio.Group
@@ -185,7 +92,7 @@ export default class TokenGovernance extends React.Component {
             itemLayout="vertical"
             size="small"
             dataSource={this.proposals}
-            renderItem={this.renderProposal}
+            renderItem={proposal => <ProposalListItem proposal={proposal} />}
           />
         ) : (
           <div className="tokens-loading">
@@ -193,48 +100,6 @@ export default class TokenGovernance extends React.Component {
             Loading proposals...
           </div>
         )}
-        <Spin size="large" spinning={!!this.submitting}>
-          <Form>
-            <Row gutter={28}>
-              <Col span={10}>
-                <h3>Proposal Title</h3>
-                <Form.Item>
-                  <Input
-                    name="title"
-                    value={this.title}
-                    placeholder="Give your proposal a Title"
-                    disabled={!this.canEdit}
-                    onChange={e => (this.title = e.target.value)}
-                  />
-                </Form.Item>
-              </Col>
-            </Row>
-            <Row>
-              <Col span={10}>
-                <h3>Proposal Description</h3>
-                <Form.Item>
-                  <TextArea
-                    name="description"
-                    value={this.description}
-                    rows={4}
-                    placeholder="Describe what your proposal is about..."
-                    disabled={!this.canEdit}
-                    onChange={e => (this.description = e.target.value)}
-                  />
-                </Form.Item>
-              </Col>
-            </Row>
-            <Form.Item>
-              <Button
-                type="primary"
-                onClick={this.sendToContract}
-                disabled={!this.canSubmit}
-              >
-                Submit Proposal
-              </Button>
-            </Form.Item>
-          </Form>
-        </Spin>
       </AppLayout>
     );
   }

--- a/src/routes/governance/token.tsx
+++ b/src/routes/governance/token.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { Fragment } from 'react';
 import { observable, computed } from 'mobx';
 import { observer } from 'mobx-react';
-import { Button, Spin, List, Radio, Card } from 'antd';
+import { Button, Spin, List, Radio, Card, Skeleton } from 'antd';
 
 import ProposalListItem from '../../components/governance/proposalListItem';
 import { proposalStore } from '../../stores/governance/proposalStore';
@@ -36,6 +37,26 @@ export default class TokenGovernance extends React.Component {
     this.showForm = false;
   }
 
+  @autobind
+  private renderListHeader() {
+    return (
+      <Fragment>
+        Show:{' '}
+        <Radio.Group
+          value={this.filterBy}
+          onChange={e => (this.filterBy = e.target.value)}
+          size="small"
+          style={{ marginBottom: '0.5rem' }}
+        >
+          <Radio.Button value="inprogress">In progress</Radio.Button>
+          <Radio.Button value="mature">Mature</Radio.Button>
+          <Radio.Button value="finalized">Finalized</Radio.Button>
+          <Radio.Button value="all">All</Radio.Button>
+        </Radio.Group>
+      </Fragment>
+    );
+  }
+
   public render() {
     return (
       <AppLayout section="governance/token">
@@ -63,6 +84,7 @@ export default class TokenGovernance extends React.Component {
             </Button>
           </div>
         </div>
+
         <Card
           title="New proposal"
           bordered={true}
@@ -74,32 +96,40 @@ export default class TokenGovernance extends React.Component {
             onCancel={this.hideProposalForm}
           />
         </Card>
+
         <Web3SubmitWarning />
-        Show:{' '}
-        <Radio.Group
-          value={this.filterBy}
-          onChange={e => (this.filterBy = e.target.value)}
-          size="small"
-          style={{ marginBottom: '0.5rem' }}
+
+        <Spin
+          spinning={proposalStore.loading}
+          size="large"
+          tip="Loading proposals..."
         >
-          <Radio.Button value="inprogress">In progress</Radio.Button>
-          <Radio.Button value="mature">Mature</Radio.Button>
-          <Radio.Button value="finalized">Finalized</Radio.Button>
-          <Radio.Button value="all">All</Radio.Button>
-        </Radio.Group>
-        {!proposalStore.loading ? (
-          <List
-            itemLayout="vertical"
-            size="small"
-            dataSource={this.proposals}
-            renderItem={proposal => <ProposalListItem proposal={proposal} />}
+          <Skeleton
+            loading={proposalStore.loading}
+            title={true}
+            paragraph={true}
           />
-        ) : (
-          <div className="tokens-loading">
-            <Spin />
-            Loading proposals...
-          </div>
-        )}
+          <Skeleton
+            loading={proposalStore.loading}
+            title={true}
+            paragraph={true}
+          />
+          <Skeleton
+            loading={proposalStore.loading}
+            title={true}
+            paragraph={true}
+          />
+          {!proposalStore.loading && (
+            <List
+              itemLayout="vertical"
+              size="small"
+              header={this.renderListHeader()}
+              locale={{ emptyText: 'No proposals' }}
+              dataSource={this.proposals}
+              renderItem={proposal => <ProposalListItem proposal={proposal} />}
+            />
+          )}
+        </Spin>
       </AppLayout>
     );
   }

--- a/src/routes/governance/token.tsx
+++ b/src/routes/governance/token.tsx
@@ -25,7 +25,6 @@ import { Proposal } from '../../stores/governance/proposal';
 import { EventEmitter } from 'events';
 
 const { TextArea } = Input;
-const { TabPane } = Tabs;
 
 @observer
 export default class TokenGovernance extends React.Component {

--- a/src/routes/governance/token.tsx
+++ b/src/routes/governance/token.tsx
@@ -3,9 +3,9 @@ import { observable, computed } from 'mobx';
 import { observer } from 'mobx-react';
 import { Button, Spin, List, Radio, Card } from 'antd';
 
+import ProposalListItem from '../../components/governance/proposalListItem';
 import { proposalStore } from '../../stores/governance/proposalStore';
 import ProposalForm from '../../components/governance/proposalForm';
-import ProposalListItem from '../../components/governance/proposal';
 import Web3SubmitWarning from '../../components/web3SubmitWarning';
 import { Proposal } from '../../stores/governance/proposal';
 import AppLayout from '../../components/appLayout';
@@ -28,7 +28,7 @@ export default class TokenGovernance extends React.Component {
 
   @computed
   private get proposals() {
-    return (proposalStore.proposals || []).filter(filters[this.filterBy]);
+    return proposalStore.proposals.filter(filters[this.filterBy]);
   }
 
   @autobind

--- a/src/stores/bridge.ts
+++ b/src/stores/bridge.ts
@@ -5,11 +5,12 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-import { reaction, action } from 'mobx';
+import { reaction, action, computed } from 'mobx';
 import autobind from 'autobind-decorator';
 import { bridge as bridgeAbi } from '../utils/abis';
 import { ContractStore } from './contractStore';
 import { plasmaConfigStore } from './plasmaConfig';
+import { BlockType } from 'web3/eth/types';
 
 export class BridgeStore extends ContractStore {
   constructor(address?: string) {
@@ -29,6 +30,11 @@ export class BridgeStore extends ContractStore {
       return;
     }
     this.address = plasmaConfigStore.bridgeAddr;
+  }
+
+  @computed
+  public get genesisBlockNumber(): Promise<BlockType> {
+    return this.contract.methods.genesisBlockNumber().call();
   }
 }
 

--- a/src/stores/governance/proposal.ts
+++ b/src/stores/governance/proposal.ts
@@ -1,21 +1,57 @@
 import { observable } from 'mobx';
 
-export class Proposal {
-  @observable public readonly description: string;
-  @observable public readonly title: string;
-  @observable public readonly hash: string;
+export interface IStoredProposalData {
+  title: string;
+  description: string;
+}
 
-  constructor(title: string, description: string, hash?: string) {
-    this.description = description;
-    this.title = title;
-    this.hash = hash;
+interface IProposal extends IStoredProposalData {
+  creator?: string;
+  hash?: string;
+}
+
+export class Proposal {
+  @observable
+  private _title: string = '';
+
+  @observable
+  private _description: string = '';
+
+  @observable
+  private _creator: string;
+
+  @observable
+  private ipfsHash: string = null;
+
+  constructor({ title, description, creator, hash }: IProposal) {
+    this._title = title;
+    this._creator = creator;
+    this._description = description;
+    this.ipfsHash = hash;
+  }
+
+  @computed get title() {
+    return this._title;
+  }
+
+  @computed get description() {
+    return this._description;
+  }
+
+  @computed get creator() {
+    return this._creator;
+  }
+
+  @computed get hash() {
+    return this.ipfsHash;
   }
 
   public toString() {
     return JSON.stringify({
       title: this.title,
       description: this.description,
-      hash: this.hash,
+      creator: this.creator,
+      hash: this.ipfsHash,
     });
   }
 }

--- a/src/stores/governance/proposal.ts
+++ b/src/stores/governance/proposal.ts
@@ -8,50 +8,23 @@ export interface IStoredProposalData {
 interface IProposal extends IStoredProposalData {
   creator?: string;
   hash?: string;
+  finalized?: boolean;
+  yesVotes?: number;
+  noVotes?: number;
+  openAt?: Date;
 }
 
 export class Proposal {
-  @observable
-  private _title: string = '';
+  @observable public readonly description: string;
+  @observable public readonly finalized: boolean;
+  @observable public readonly yesVotes: number;
+  @observable public readonly noVotes: number;
+  @observable public readonly creator: string;
+  @observable public readonly openAt: Date;
+  @observable public readonly title: string;
+  @observable public readonly hash: string;
 
-  @observable
-  private _description: string = '';
-
-  @observable
-  private _creator: string;
-
-  @observable
-  private ipfsHash: string = null;
-
-  constructor({ title, description, creator, hash }: IProposal) {
-    this._title = title;
-    this._creator = creator;
-    this._description = description;
-    this.ipfsHash = hash;
-  }
-
-  @computed get title() {
-    return this._title;
-  }
-
-  @computed get description() {
-    return this._description;
-  }
-
-  @computed get creator() {
-    return this._creator;
-  }
-
-  @computed get hash() {
-    return this.ipfsHash;
-  }
-
-  public toString() {
-    return JSON.stringify({
-      title: this.title,
-      description: this.description,
-      creator: this.creator,
-      hash: this.ipfsHash,
-    });
+  constructor(proposalObject: IProposal) {
+    Object.assign(this, proposalObject);
   }
 }

--- a/src/stores/governance/proposal.ts
+++ b/src/stores/governance/proposal.ts
@@ -1,5 +1,7 @@
 import { observable } from 'mobx';
 
+const SEVEN_DAYS = 604800000; // 1000 * 60 * 60 * 24 * 7 = 7 days
+
 export interface IStoredProposalData {
   title: string;
   description: string;
@@ -26,5 +28,10 @@ export class Proposal {
 
   constructor(proposalObject: IProposal) {
     Object.assign(this, proposalObject);
+  }
+
+  public isMature(): boolean {
+    const timeSinceOpen = Date.now() - this.openAt.getTime();
+    return timeSinceOpen > SEVEN_DAYS;
   }
 }

--- a/src/stores/governance/proposalStore.ts
+++ b/src/stores/governance/proposalStore.ts
@@ -21,6 +21,9 @@ export class ProposalStore {
   @observable
   public proposals: Proposal[];
 
+  @observable
+  public loading: boolean;
+
   constructor() {
     when(() => !!bridgeStore.contract, this.loadAll);
   }
@@ -81,6 +84,7 @@ export class ProposalStore {
   @autobind
   @action
   private async loadAll() {
+    this.loading = true;
     console.log('Reading proposals..');
     const fromBlock = await bridgeStore.genesisBlockNumber;
     const events = await tokenGovernance.contract.getPastEvents(
@@ -113,6 +117,7 @@ export class ProposalStore {
         })
       )
     );
+    this.loading = false;
     console.log([...this.proposals]);
   }
 

--- a/src/stores/governance/proposalStore.ts
+++ b/src/stores/governance/proposalStore.ts
@@ -72,6 +72,7 @@ export class ProposalStore {
       .then(_ => {
         const proposal = new Proposal({ title, description, hash });
         progress.emit(ProposalLifecycle.CREATED, proposal);
+        this.loadAll();
         return proposal;
       })
       .catch(e => {

--- a/src/stores/governance/proposalStore.ts
+++ b/src/stores/governance/proposalStore.ts
@@ -19,7 +19,7 @@ export enum ProposalLifecycle {
 
 export class ProposalStore {
   @observable
-  public proposals: Proposal[];
+  public proposals: Proposal[] = observable.array([]);
 
   @observable
   public loading: boolean;

--- a/src/stores/governance/proposalStore.ts
+++ b/src/stores/governance/proposalStore.ts
@@ -92,16 +92,28 @@ export class ProposalStore {
       await Promise.all(
         events.map(async ({ returnValues }) => {
           const { proposalHash, initiator } = returnValues;
+          const {
+            openTime,
+            finalized,
+            yesVotes,
+            noVotes,
+          } = await tokenGovernance.contract.methods
+            .proposals(proposalHash)
+            .call();
           const data = await this.loadFromIPFS(proposalHash);
           return new Proposal({
             ...data,
             creator: initiator,
             hash: proposalHash,
+            openAt: new Date(openTime * 1000),
+            finalized,
+            yesVotes,
+            noVotes,
           });
         })
       )
     );
-    console.log(this.proposals);
+    console.log([...this.proposals]);
   }
 
   private async loadFromIPFS(

--- a/src/stores/governance/proposalStore.ts
+++ b/src/stores/governance/proposalStore.ts
@@ -22,7 +22,7 @@ export class ProposalStore {
   public proposals: Proposal[] = observable.array([]);
 
   @observable
-  public loading: boolean;
+  public loading: boolean = true;
 
   constructor() {
     when(() => !!bridgeStore.contract, this.loadAll);

--- a/src/stores/governance/proposalStore.ts
+++ b/src/stores/governance/proposalStore.ts
@@ -1,8 +1,12 @@
-import { tokenGovernance } from '../contracts/tokenGovernance';
-import * as IPFS from '../ipfs';
-import { Proposal } from './proposal';
+import { when, observable, action } from 'mobx';
+import autobind from 'autobind-decorator';
 import { EventEmitter } from 'events';
+
+import { tokenGovernance } from '../contracts/tokenGovernance';
+import { Proposal, IStoredProposalData } from './proposal';
 import { web3InjectedStore } from '../web3/injected';
+import { bridgeStore } from '../bridge';
+import * as IPFS from '../ipfs';
 
 const { hexToCid, cidToHex } = IPFS;
 
@@ -14,6 +18,13 @@ export enum ProposalLifecycle {
 }
 
 export class ProposalStore {
+  @observable
+  public proposals: Proposal[];
+
+  constructor() {
+    when(() => !!bridgeStore.contract, this.loadAll);
+  }
+
   private async storeToIPFS(
     title: string,
     description: string,
@@ -27,21 +38,21 @@ export class ProposalStore {
     return proposalHash;
   }
 
-  private async submitToContract(proposal: Proposal, progress: EventEmitter) {
-    progress.emit(ProposalLifecycle.SUBMIT_TO_CONTRACT, proposal);
+  private async submitToContract(
+    title: string,
+    hash: string,
+    progress: EventEmitter
+  ) {
+    progress.emit(ProposalLifecycle.SUBMIT_TO_CONTRACT, { title, hash });
     const [from] = await web3InjectedStore.instance.eth.getAccounts();
     const tx = tokenGovernance.iContract.methods
-      .registerProposal(proposal.hash)
+      .registerProposal(hash)
       .send({ from });
 
     tokenGovernance.watchTx(tx, 'registerProposal', {
       message:
         'Registering token governance proposal. ' +
         'A stake of 5000 LEAP will be deducted from your account',
-    });
-
-    tx.then(_ => {
-      progress.emit(ProposalLifecycle.CREATED, proposal);
     });
 
     return tx;
@@ -52,23 +63,55 @@ export class ProposalStore {
     description: string,
     progress: EventEmitter = new EventEmitter()
   ): Promise<Proposal> {
-    const proposalHash = await this.storeToIPFS(title, description, progress);
-    const proposal = new Proposal(title, description, proposalHash);
-    await this.submitToContract(proposal, progress).catch(e => {
-      console.error(e);
-      progress.emit(ProposalLifecycle.FAILED_TO_CREATE, { title });
-    });
+    const hash = await this.storeToIPFS(title, description, progress);
 
-    return proposal;
+    return this.submitToContract(title, hash, progress)
+      .then(_ => {
+        const proposal = new Proposal({ title, description, hash });
+        progress.emit(ProposalLifecycle.CREATED, proposal);
+        return proposal;
+      })
+      .catch(e => {
+        console.error(e);
+        progress.emit(ProposalLifecycle.FAILED_TO_CREATE, { title });
+        return null;
+      });
   }
 
-  public async load(proposalHash: string): Promise<Proposal> {
+  @autobind
+  @action
+  private async loadAll() {
+    console.log('Reading proposals..');
+    const fromBlock = await bridgeStore.genesisBlockNumber;
+    const events = await tokenGovernance.contract.getPastEvents(
+      'ProposalRegistered',
+      { fromBlock }
+    );
+
+    this.proposals = observable.array(
+      await Promise.all(
+        events.map(async ({ returnValues }) => {
+          const { proposalHash, initiator } = returnValues;
+          const data = await this.loadFromIPFS(proposalHash);
+          return new Proposal({
+            ...data,
+            creator: initiator,
+            hash: proposalHash,
+          });
+        })
+      )
+    );
+    console.log(this.proposals);
+  }
+
+  private async loadFromIPFS(
+    proposalHash: string
+  ): Promise<IStoredProposalData> {
     const ipfsHash = hexToCid(proposalHash);
     console.log('Retrieving from IPFS', { proposalHash, ipfsHash });
     const rawData = await IPFS.get(ipfsHash);
     console.log('Retrieved', { rawData });
-    const proposal = JSON.parse(rawData.toString());
-    return new Proposal(proposal.title, proposal.description, proposalHash);
+    return JSON.parse(rawData.toString());
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -227,3 +227,34 @@ h2:first-child {
   flex-direction: column;
   align-items: center;
 }
+
+.token-governance-proposal {
+  padding-top: 1.2rem !important;
+  padding-bottom: 1.2rem !important;
+}
+
+.token-governance-proposal .ant-list-item-meta-description {
+  color: rgba(0,0,0,.45) !important;
+}
+
+.token-governance-proposal .ant-list-item-meta {
+  margin-bottom: 0.2rem;
+}
+
+.token-governance-proposal .ant-list-item-meta-title {
+  margin-bottom: 0.5rem;
+}
+
+.with-markdown h1,
+.with-markdown h2 {
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.with-markdown ul {
+  margin-left: 1rem;
+}
+
+.with-markdown p {
+  margin-bottom: 0.5rem;
+}

--- a/src/utils/abis/tokenGovernance.ts
+++ b/src/utils/abis/tokenGovernance.ts
@@ -1,3 +1,5 @@
+import { ABIDefinition } from 'web3/eth/abi';
+
 export default [
   {
     constant: true,
@@ -268,4 +270,4 @@ export default [
     stateMutability: 'nonpayable',
     type: 'function',
   },
-];
+] as ABIDefinition[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,6 +2205,11 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
+bail@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
+  integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -2664,6 +2669,21 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
 chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
@@ -2773,6 +2793,11 @@ coa@^2.0.2:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collapse-white-space@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
+  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -3504,6 +3529,14 @@ dom-serializer@0:
     domelementtype "^1.3.0"
     entities "^1.1.1"
 
+dom-serializer@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -3516,11 +3549,23 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
 
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   dependencies:
     domelementtype "1"
+
+domhandler@^3.0, domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -3535,6 +3580,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.0.0.tgz#15b8278e37bfa8468d157478c58c367718133c08"
+  integrity sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 dot-prop@^4.1.1:
   version "4.2.0"
@@ -3637,6 +3691,11 @@ enquire.js@^2.1.6:
 entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+
+entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
+  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
 err-code@^2.0.0:
   version "2.0.0"
@@ -3881,7 +3940,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -4556,6 +4615,16 @@ html-minifier@^3.2.3:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
+html-to-react@^1.3.4:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.2.tgz#7b628ab56cd63a52f2d0b79d0fa838a51f088a57"
+  integrity sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==
+  dependencies:
+    domhandler "^3.0"
+    htmlparser2 "^4.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.26"
+
 html-webpack-plugin@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
@@ -4578,6 +4647,16 @@ htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -4743,7 +4822,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
@@ -4902,6 +4981,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -4916,7 +5008,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -4961,6 +5053,11 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -5036,6 +5133,11 @@ is-glob@^4.0.0:
 is-hex-prefixed@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-ip@^3.1.0:
   version "3.1.0"
@@ -5145,9 +5247,19 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
+  integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-word-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
+  integrity sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -5723,6 +5835,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
+  integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
 matchmediaquery@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.2.1.tgz#223c7005793de03e47ce92b13285a72c44ada2cf"
@@ -5736,6 +5853,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
 
 mdn-data@~1.1.0:
   version "1.1.4"
@@ -6500,6 +6624,18 @@ parse-duration@^0.1.1:
   resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-0.1.2.tgz#9f1403ab86d6139f88a0e55ea6783afeca3110c4"
   integrity sha512-0qfMZyjOUFBeEIvJ5EayfXJqaEXxQ+Oj2b7tWJM3hvEXvXsYCk05EDVI23oYnEw2NaFYUWdABEVPBvBMh8L/pA==
 
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-headers@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.2.tgz#9545e8a4c1ae5eaea7d24992bca890281ed26e34"
@@ -6984,7 +7120,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.6.x:
+prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.6.x, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
@@ -7111,6 +7247,11 @@ raf@^3.4.0, raf@^3.4.1:
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   dependencies:
     performance-now "^2.1.0"
+
+ramda@^0.26:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
@@ -7541,6 +7682,11 @@ react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
 
+react-is@^16.8.6:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
+
 react-lazy-load@^3.0.13:
   version "3.0.13"
   resolved "https://registry.yarnpkg.com/react-lazy-load/-/react-lazy-load-3.0.13.tgz#3b0a92d336d43d3f0d73cbe6f35b17050b08b824"
@@ -7553,6 +7699,20 @@ react-lazy-load@^3.0.13:
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
+react-markdown@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
+  integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-responsive@^4.1.0:
   version "4.1.0"
@@ -7744,6 +7904,27 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -7762,7 +7943,7 @@ repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
 
-repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -7771,6 +7952,11 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request@^2.79.0, request@^2.83.0:
   version "2.88.0"
@@ -8313,6 +8499,11 @@ staged-git-files@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
 
+state-toggle@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
+  integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -8711,6 +8902,21 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
+  integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+trough@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
+  integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
 ts-loader@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-4.5.0.tgz#a1ce70b2dc799941fb2197605f0d67874097859b"
@@ -8834,6 +9040,14 @@ underscore@1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
+unherit@^1.0.4:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
+  integrity sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==
+  dependencies:
+    inherits "^2.0.0"
+    xtend "^4.0.0"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -8852,6 +9066,18 @@ unicode-match-property-value-ecmascript@^1.0.2:
 unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
+
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -8881,6 +9107,42 @@ unique-slug@^2.0.0:
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.1.tgz#5e9edc6d1ce8fb264db18a507ef9bd8544451ca6"
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -9030,6 +9292,28 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -9439,6 +9723,11 @@ ws@^3.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
+
 xhr-request-promise@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz#343c44d1ee7726b8648069682d0f840c83b4261d"
@@ -9477,6 +9766,11 @@ xregexp@4.0.0:
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xtend@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What does this PR do?

- [x] Deployed new Rinkeby TokenGovernance contract as the old one was spoiled with non-IPFS hashes. Address: `0x858d6D9C6E5900BA06ed9898d545C890b660dE35`
- [x] Governance screen split in two: governance/plasma and governance/token. SubMenu is used for navigation. Old route `/governance` still leads to Plasma Governance for backward compatibility. [Link](https://github.com/leapdao/bridge-ui/pull/278/files#diff-38682f47b0cf12c516bc3714fc45d0fdR36)
- [x] Showing proposals as List with filters, not Tabs. Extracted `ProposalListItem` component which renders a proposal
- [x] "Submit Proposal" and "Finalize Proposals" Tabs replaced with action Buttons
- [x] Extracted `ProposalForm` component
- [x] ProposalStore: fetching token proposals by scanning for `ProposalRegistered ` events on the root chain
- [x] ProposalStore: for each of the fetched proposals download proposal data from IPFS
- [x] Showing progress indicator for each of the steps of Proposal creation (IPFS upload, Submission to contract, Success/Failure)
- [x] ProposalListItem: render proposal description as Markdown (see third proposal as example)
- [x] Proposal: added all the other attributes (yesVotes, finalized etc) to the domain object. [Link](https://github.com/leapdao/bridge-ui/pull/278/files#diff-6b7f4f61d9583ab1a93250a5218c9c50R19)

## Links

Closes #273 