### PR TITLE
fix exits

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ethereumjs-util": "6.0.0",
     "fork-ts-checker-webpack-plugin": "^0.4.15",
     "jsbi-utils": "^1.0.0",
-    "leap-core": "0.38.0",
+    "leap-core": "2.0.0",
     "mobx": "^5.0.3",
     "mobx-react": "^5.2.3",
     "prop-types": "^15.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3660,6 +3660,11 @@ eventemitter3@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.1.1.tgz#47786bdaa087caf7b1b75e73abc5c7d540158cd0"
 
+eventemitter3@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
 eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -5108,15 +5113,16 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.38.0.tgz#808ddff55bb5189771e0fbc2a086210529a17b4f"
-  integrity sha512-mjS3UOiJp05wRKRsURI1u8XzZ/4HmScpj3cpAGRC9ls4QShu/XAf2CpK297PWAfHT+xQTLyd3OxBNujhuTXamA==
+leap-core@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-2.0.0.tgz#e0ce5000bf77afd72f5a72236d6b80e82e8d3f19"
+  integrity sha512-DqbWSrYNz+ZGIROXfT7SBUC0FHon6rrv6I7RCrxbzqjDsHHh6lmpMW6v+kkJtYYRe6TkalxPZMz0HRgo+ndtbw==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"
     jsbi-utils "^1.0.0"
     node-fetch "^2.3.0"
+    web3-core-promievent "^1.2.4"
 
 less-loader@^4.1.0:
   version "4.1.0"
@@ -8600,6 +8606,14 @@ web3-core-promievent@1.0.0-beta.33:
   dependencies:
     any-promise "1.3.0"
     eventemitter3 "1.1.1"
+
+web3-core-promievent@^1.2.4:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.6.tgz#b1550a3a4163e48b8b704c1fe4b0084fc2dad8f5"
+  integrity sha512-km72kJef/qtQNiSjDJJVHIZvoVOm6ytW3FCYnOcCs7RIkviAb5JYlPiye0o4pJOLzCXYID7DK7Q9bhY8qWb1lw==
+  dependencies:
+    any-promise "1.3.0"
+    eventemitter3 "3.1.2"
 
 web3-core-requestmanager@1.0.0-beta.33:
   version "1.0.0-beta.33"


### PR DESCRIPTION
## What's in this PR

Since testnet upgrade, getPeriodData API has changed (breaking change). Here we adjusting code to support the latest testnet.

- use new leap-core@2.0.0
- adjust `getProof` API

## Links

Closes #267 